### PR TITLE
Fix handling of deep multiparti variables, eg. VAR1%FIELD2%FIELD3

### DIFF
--- a/src/fortran/ofp/XMLPrinter.java
+++ b/src/fortran/ofp/XMLPrinter.java
@@ -902,8 +902,7 @@ public class XMLPrinter extends XMLPrinterBase {
 	}
 
 	public void data_ref(int numPartRef) {
-		if (numPartRef > 1) {
-			assert numPartRef == 2;
+		for (int i = 1; i < numPartRef; ++i) {
 			assert context.getTagName().equals("name");
 			Element innerName = context;
 			ArrayList<Element> elements = contextNodes();


### PR DESCRIPTION
data_ref: Hoist `name` elements in a loop to fix handling of multipart variables (`numPartRef > 2`), such as `VAR1%FIELD2%FIELD3`. An example code to illustrate the effect is:

```
SUBROUTINE TEST_ASSOC(VAR1, VAR2)                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                
IMPLICIT NONE                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
TYPE(SOME_TYPE)      , INTENT (INOUT) :: VAR1                                                                                                                                                                                                                                   
TYPE(SOME_OTHER_TYPE), INTENT (INOUT) :: VAR2                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
ASSOCIATE(V1=>VAR1%FIELD1, V2=>VAR2%FIELD2%FIELD3)                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                
IF (VAR2%FIELD4%BOOL1 == 1) THEN                                                                                                                                                                                                                                                
   V1(:) = V2(:)                                                                                                                                                                                                                                                                
END IF                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                
END ASSOCIATE                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
END SUBROUTINE TEST_ASSOC           
```