### PR TITLE
literal_constant: Capture stray `kind-param` element for literals

### DIFF
--- a/src/fortran/ofp/XMLPrinter.java
+++ b/src/fortran/ofp/XMLPrinter.java
@@ -206,7 +206,14 @@ public class XMLPrinter extends XMLPrinterBase {
 	}
 
 	public void int_literal_constant(Token digitString, Token kindParam) {
+	    if (kindParam != null) {
+		Element kind = contextNode(-1);
+		assert kind.getTagName().equals("kind-param");
 		contextOpen("literal");
+		moveHere(kind);
+	    } else {
+		contextOpen("literal");
+	    }
 		setAttribute("type", "int");
 		setAttribute("value", digitString);
 		super.int_literal_constant(digitString, kindParam);
@@ -220,7 +227,14 @@ public class XMLPrinter extends XMLPrinterBase {
 	}
 
 	public void real_literal_constant(Token realConstant, Token kindParam) {
+	    if (kindParam != null) {
+		Element kind = contextNode(-1);
+		assert kind.getTagName().equals("kind-param");
 		contextOpen("literal");
+		moveHere(kind);
+	    } else {
+		contextOpen("literal");
+	    }
 		setAttribute("type", "real");
 		setAttribute("value", realConstant);
 		super.real_literal_constant(realConstant, kindParam);
@@ -248,7 +262,14 @@ public class XMLPrinter extends XMLPrinterBase {
 	}
 
 	public void logical_literal_constant(Token logicalValue, boolean isTrue, Token kindParam) {
+	    if (kindParam != null) {
+		Element kind = contextNode(-1);
+		assert kind.getTagName().equals("kind-param");
 		contextOpen("literal");
+		moveHere(kind);
+	    } else {
+		contextOpen("literal");
+	    }
 		setAttribute("type", "bool");
 		setAttribute("value", isTrue);
 		super.logical_literal_constant(logicalValue, isTrue, kindParam);

--- a/test/examples/arithmetic_kind.f90
+++ b/test/examples/arithmetic_kind.f90
@@ -1,0 +1,13 @@
+subroutine test_arithmetic(var1, var2, var3)
+
+use mydatatypes, only: float64
+
+implicit none
+
+var1 = 100._float64 * var2
+
+if (var2 >= 0.5_float64 + var3) then
+  var2 = var3 * (1._float64 - var2)
+end if
+
+end subroutine test_arithmetic


### PR DESCRIPTION
The `kind-param` node gets processed before the appropriate context
for literal constants is opened, leading to stray `kind-param` elements
outside of the corresponding `literal` nodes.

This creates problems for further expression processing, for example when
moving the appropriate `target` and `value` nodes in an `assignment_stmt`.
The ensuing side-effects of this can be quite severe.

To illustrate this problem a small test might look like t his:
```
SUBROUTINE TEST_ARITHMETIC(VAR1, VAR2, VAR3)                                                                                                                                                              
USE MYDATATYPES, ONLY: FLOAT128                                                                                                                                                                                                    
IMPLICIT NONE                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                
VAR1 = 100._FLOAT128 * EPSILON(VAR2)                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                
END SUBROUTINE TEST_ARITHMETIC
```